### PR TITLE
clean + Maptiler fix

### DIFF
--- a/landez/tiles.py
+++ b/landez/tiles.py
@@ -4,7 +4,7 @@ import logging
 from gettext import gettext as _
 import json
 import mimetypes
-import string
+import uuid
 
 from StringIO import StringIO
 
@@ -326,6 +326,7 @@ class MBTilesBuilder(TilesManager):
         lat = self.bounds[1] + (self.bounds[3] - self.bounds[1])/2
         lon = self.bounds[0] + (self.bounds[2] - self.bounds[0])/2
         metadata = {}
+        metadata['name'] = str(uuid.uuid4())
         metadata['format'] = self._tile_extension[1:]
         metadata['minzoom'] = self.zoomlevels[0]
         metadata['maxzoom'] = self.zoomlevels[-1]


### PR DESCRIPTION
- removed unused `import string`
- added a name metadata to prevent Maptiler crash
