### PR TITLE
Fix assert statement for checking content type

### DIFF
--- a/landez/sources.py
+++ b/landez/sources.py
@@ -229,7 +229,7 @@ class WMSReader(TileSource):
         try:
             logger.debug(_("Download '%s'") % url)
             request = requests.get(url, headers=self.headers)
-            assert request.headers == self.wmsParams['format'], "Invalid WMS response type : %s" % self.headers
+            assert request.headers['Content-Type'] == self.wmsParams['format'], "Invalid WMS response type : %s" % request.headers['Content-Type']
             return request.content
         except (AssertionError, IOError):
             raise ExtractionError


### PR DESCRIPTION
This fixes a bug concerning tile extraction from WMS.

In 2.5.0, the assert statement in mbreader.tile(z, x, y) fails
because it compares a dictionary and a string.

Tested with GeoServer 2.13.0.